### PR TITLE
Specify minimum version of Node

### DIFF
--- a/package.json
+++ b/package.json
@@ -15,6 +15,9 @@
   "bin": {
     "ucat": "./ucat.js"
   },
+  "engines": {
+    "node": ">=8.12"
+  },
   "dependencies": {
     "napi-macros": "^1.8.1",
     "node-gyp-build": "^3.5.0",


### PR DESCRIPTION
- Node versions less than 8.12 do not work with that latest version of utp-native. This
commit at least helps inform users if they don't have a new enough
version of node. This will cause `npm install` to fail if users of the
library have run this command `npm config set engine-strict true`.

Signed-off-by: Cody W. Eilar <Cody.Eilar@Gmail.com>