### PR TITLE
feature: add musl pre-built builds for utp-native

### DIFF
--- a/.github/workflows/build-release.yml
+++ b/.github/workflows/build-release.yml
@@ -7,7 +7,7 @@ jobs:
   build:
     strategy:
       matrix:
-        os: [windows-latest, macos-latest, ubuntu-18.04]
+        os: [windows-latest, macos-latest, ubuntu-20.04]
     runs-on: ${{ matrix.os }}
     name: Build
     steps:
@@ -16,14 +16,14 @@ jobs:
         with:
           node-version: 16.x
       - run: sudo apt install -y musl musl-tools
-        if: ${{ matrix.os == 'ubuntu-18.04' }}
+        if: ${{ matrix.os == 'ubuntu-20.04' }}
       - run: npm run fetch-libutp
       - run: npm install
       - run: npm run prebuild
       - run: npm run prebuild-ia32
         if: ${{ matrix.os == 'windows-latest' }}
       - run: npm run prebuild-musl
-        if: ${{ matrix.os == 'ubuntu-18.04' }}
+        if: ${{ matrix.os == 'ubuntu-20.04' }}
         env:
           CC: musl-gcc
           CXX: musl-gcc
@@ -60,7 +60,7 @@ jobs:
       - name: Compress builds
         run: |
           tar --create --verbose --file="./${{ steps.get_version.outputs.VERSION }}-windows-all.tar" --directory "prebuilds/windows-latest" .
-          tar --create --verbose --file="./${{ steps.get_version.outputs.VERSION }}-linux-x86.tar" --directory "prebuilds/ubuntu-18.04" .
+          tar --create --verbose --file="./${{ steps.get_version.outputs.VERSION }}-linux-x86.tar" --directory "prebuilds/ubuntu-20.04" .
           tar --create --verbose --file="./${{ steps.get_version.outputs.VERSION }}-osx-x86.tar" --directory "prebuilds/macos-latest" .
       - name: Upload x86 build
         uses: actions/upload-release-asset@v1

--- a/.github/workflows/build-release.yml
+++ b/.github/workflows/build-release.yml
@@ -54,7 +54,7 @@ jobs:
       - name: Compress builds
         run: |
           tar --create --verbose --file="./${{ steps.get_version.outputs.VERSION }}-windows-all.tar" --directory "prebuilds/windows-latest" .
-          tar --create --verbose --file="./${{ steps.get_version.outputs.VERSION }}-linux-x86.tar" --directory "prebuilds/ubuntu-16.04" .
+          tar --create --verbose --file="./${{ steps.get_version.outputs.VERSION }}-linux-x86.tar" --directory "prebuilds/ubuntu-latest" .
           tar --create --verbose --file="./${{ steps.get_version.outputs.VERSION }}-osx-x86.tar" --directory "prebuilds/macos-latest" .
       - name: Upload x86 build
         uses: actions/upload-release-asset@v1

--- a/.github/workflows/build-release.yml
+++ b/.github/workflows/build-release.yml
@@ -7,7 +7,7 @@ jobs:
   build:
     strategy:
       matrix:
-        os: [windows-latest, macos-latest, ubuntu-16.04]
+        os: [windows-latest, macos-latest, ubuntu-latest]
     runs-on: ${{ matrix.os }}
     name: Build
     steps:
@@ -16,7 +16,7 @@ jobs:
         with:
           node-version: 16.x
       - run: sudo apt install -y musl
-        if: ${{ matrix.os == 'ubuntu-16.04' }}
+        if: ${{ matrix.os == 'ubuntu-latest' }}
       - run: npm run fetch-libutp
       - run: npm install
       - run: npm run prebuild

--- a/.github/workflows/build-release.yml
+++ b/.github/workflows/build-release.yml
@@ -29,7 +29,7 @@ jobs:
           path: ./prebuilds
   release:
     name: Create Release
-    runs-on: ubuntu-16.04
+    runs-on: ubuntu-latest
     needs: build
     steps:
       - name: Checkout code

--- a/.github/workflows/build-release.yml
+++ b/.github/workflows/build-release.yml
@@ -15,14 +15,18 @@ jobs:
       - uses: actions/setup-node@v1
         with:
           node-version: 16.x
-      - run: sudo apt install -y musl
+      - run: sudo apt install -y musl musl-tools
         if: ${{ matrix.os == 'ubuntu-latest' }}
       - run: npm run fetch-libutp
       - run: npm install
       - run: npm run prebuild
-      - run: npm run prebuild-musl
       - run: npm run prebuild-ia32
         if: ${{ matrix.os == 'windows-latest' }}
+      - run: npm run prebuild-musl
+        if: ${{ matrix.os == 'ubuntu-latest' }}
+        env:
+          CC: musl-gcc
+          CXX: musl-gcc
       - uses: actions/upload-artifact@v2
         with:
           name: ${{ matrix.os }}

--- a/.github/workflows/build-release.yml
+++ b/.github/workflows/build-release.yml
@@ -35,6 +35,8 @@ jobs:
     name: Create Release
     runs-on: ubuntu-latest
     needs: build
+    permissions:
+      contents: write
     steps:
       - name: Checkout code
         uses: actions/checkout@v2

--- a/.github/workflows/build-release.yml
+++ b/.github/workflows/build-release.yml
@@ -7,7 +7,7 @@ jobs:
   build:
     strategy:
       matrix:
-        os: [windows-latest, macos-latest, ubuntu-latest]
+        os: [windows-latest, macos-latest, ubuntu-18.04]
     runs-on: ${{ matrix.os }}
     name: Build
     steps:
@@ -16,14 +16,14 @@ jobs:
         with:
           node-version: 16.x
       - run: sudo apt install -y musl musl-tools
-        if: ${{ matrix.os == 'ubuntu-latest' }}
+        if: ${{ matrix.os == 'ubuntu-18.04' }}
       - run: npm run fetch-libutp
       - run: npm install
       - run: npm run prebuild
       - run: npm run prebuild-ia32
         if: ${{ matrix.os == 'windows-latest' }}
       - run: npm run prebuild-musl
-        if: ${{ matrix.os == 'ubuntu-latest' }}
+        if: ${{ matrix.os == 'ubuntu-18.04' }}
         env:
           CC: musl-gcc
           CXX: musl-gcc
@@ -60,7 +60,7 @@ jobs:
       - name: Compress builds
         run: |
           tar --create --verbose --file="./${{ steps.get_version.outputs.VERSION }}-windows-all.tar" --directory "prebuilds/windows-latest" .
-          tar --create --verbose --file="./${{ steps.get_version.outputs.VERSION }}-linux-x86.tar" --directory "prebuilds/ubuntu-latest" .
+          tar --create --verbose --file="./${{ steps.get_version.outputs.VERSION }}-linux-x86.tar" --directory "prebuilds/ubuntu-18.04" .
           tar --create --verbose --file="./${{ steps.get_version.outputs.VERSION }}-osx-x86.tar" --directory "prebuilds/macos-latest" .
       - name: Upload x86 build
         uses: actions/upload-release-asset@v1

--- a/.github/workflows/build-release.yml
+++ b/.github/workflows/build-release.yml
@@ -14,7 +14,7 @@ jobs:
       - uses: actions/checkout@v2.1.0
       - uses: actions/setup-node@v1
         with:
-          node-version: 14.x
+          node-version: 16.x
       - run: sudo apt install -y musl
         if: ${{ matrix.os == 'ubuntu-16.04' }}
       - run: npm run fetch-libutp

--- a/.github/workflows/build-release.yml
+++ b/.github/workflows/build-release.yml
@@ -15,9 +15,12 @@ jobs:
       - uses: actions/setup-node@v1
         with:
           node-version: 14.x
+      - run: sudo apt install -y musl
+        if: ${{ matrix.os == 'ubuntu-16.04' }}
       - run: npm run fetch-libutp
       - run: npm install
       - run: npm run prebuild
+      - run: npm run prebuild-musl
       - run: npm run prebuild-ia32
         if: ${{ matrix.os == 'windows-latest' }}
       - uses: actions/upload-artifact@v2

--- a/.gitmodules
+++ b/.gitmodules
@@ -1,3 +1,3 @@
 [submodule "libutp"]
 	path = deps/libutp
-	url = git://github.com/mafintosh/libutp.git
+	url = https://github.com/mafintosh/libutp.git

--- a/package.json
+++ b/package.json
@@ -9,8 +9,9 @@
     "test": "standard && tape test/net.js test/sockets.js test/udp.js",
     "install": "node-gyp-build",
     "fetch-libutp": "git submodule update --recursive --init",
-    "prebuild": "prebuildify --napi --strip",
-    "prebuild-ia32": "prebuildify --napi --strip --arch=ia32"
+    "prebuild": "prebuildify --napi --strip --tag-libc",
+    "prebuild-musl": "prebuildify --napi --strip --libc=musl --tag-libc",
+    "prebuild-ia32": "prebuildify --napi --strip --arch=ia32 --tag-libc"
   },
   "bin": {
     "ucat": "./ucat.js"

--- a/package.json
+++ b/package.json
@@ -29,7 +29,8 @@
   "devDependencies": {
     "prebuildify": "^4.1.2",
     "standard": "^14.3.1",
-    "tape": "^4.11.0"
+    "tape": "^4.11.0",
+    "node-gyp": "^10.1.0"
   },
   "repository": {
     "type": "git",


### PR DESCRIPTION
**What is the purpose of this pull request? (put an "X" next to item)**

- [ ] Documentation update
- [ ] Bug fix
- [x] New feature
- [ ] Other, please explain:

**What changes did you make? (Give an overview)**

This PR updates the GitHub actions to get it back to a running state and introduces `musl` pre-built builds of `utp-native` to allow utp-native to function on alpine-based docker images or systems which use musl over glibc.

The changes include:
- changing runners from ubuntu-16.04 (discontinued) to ubuntu-latest
- updates node version from 14.x to 16.x (14 no longer seems to be published for MacOS)
- adds `musl-tools` and `musl` for Ubuntu to allow musl pre-builds to be generated
- adds `node-gyp` to the devDependencies, as this is required by `node-gyp-build`, and the version installed in the GitHub npm cache for the ubuntu-latest runner does not work with the version of python installed in the runner.

**Which issue (if any) does this pull request address?**

- fixes https://github.com/mafintosh/utp-native/issues/49

